### PR TITLE
add CA certificate to net_http_options

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    actionhook (1.0.1)
+    actionhook (1.0.2)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/actionhook/core/configuration.rb
+++ b/lib/actionhook/core/configuration.rb
@@ -7,7 +7,7 @@ module ActionHook
       DEFAULT_READ_TIMEOUT_IN_SECONDS = 15
       DEFAULT_HASH_HEADER_NAME = 'SHA256-FINGERPRINT'
       attr_accessor :open_timeout, :read_timeout, :hash_header_name,
-        :allow_private_ips
+        :allow_private_ips, :ca_file
 
       attr_writer :blocked_custom_ip_ranges
 
@@ -15,20 +15,23 @@ module ActionHook
         read_timeout: DEFAULT_READ_TIMEOUT_IN_SECONDS,
         hash_header_name: DEFAULT_HASH_HEADER_NAME,
         allow_private_ips: false,
-        blocked_custom_ip_ranges: []
+        blocked_custom_ip_ranges: [],
+        ca_file: nil
       )
         @open_timeout = open_timeout
         @read_timeout = read_timeout
         @hash_header_name = hash_header_name
         @allow_private_ips = allow_private_ips
         @blocked_custom_ip_ranges = blocked_custom_ip_ranges || []
+        @ca_file = ca_file
       end
 
       def net_http_options
         {
           open_timeout: @open_timeout,
-          read_timeout: @read_timeout
-        }
+          read_timeout: @read_timeout,
+          ca_file: @ca_file
+        }.compact
       end
 
       def blocked_custom_ip_ranges

--- a/lib/actionhook/version.rb
+++ b/lib/actionhook/version.rb
@@ -1,3 +1,3 @@
 module ActionHook
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end

--- a/spec/core/configuration_spec.rb
+++ b/spec/core/configuration_spec.rb
@@ -1,11 +1,16 @@
 describe ActionHook::Core::Configuration do
+  let(:certificate_path) { '/tmp/client.crt' }
 
   describe 'net_http_options' do
-    it 'returns the default values' do
-      expect(described_class.new.net_http_options).to eql(
+    let(:default_options) do
+      {
         open_timeout: described_class::DEFAULT_OPEN_TIMEOUT_IN_SECONDS,
         read_timeout: described_class::DEFAULT_READ_TIMEOUT_IN_SECONDS
-      )
+      }
+    end
+
+    it 'returns the default values' do
+      expect(described_class.new.net_http_options).to eql(default_options)
     end
 
     it 'allows custom timeout values' do
@@ -15,6 +20,12 @@ describe ActionHook::Core::Configuration do
       )
     end
 
+    context 'when ca_file is passed in arguments' do
+      it 'returns default options with ca_file path' do
+        options = described_class.new(ca_file: certificate_path).net_http_options
+        expect(options).to eql(default_options.merge({ ca_file: certificate_path }))
+      end
+    end
   end
 
   describe 'has_header_name' do
@@ -42,6 +53,17 @@ describe ActionHook::Core::Configuration do
       expect(config.allow_private_ips).to be true
     end
 
+  end
+
+  describe 'allow to configure with ca_file' do
+    it 'sets to nil by default' do
+      expect(described_class.new.ca_file).to be_nil
+    end
+
+    it 'allows to configure request with ca_file' do
+      config = described_class.new(ca_file: certificate_path)
+      expect(config.ca_file). to be certificate_path
+    end
   end
 
   describe 'blocked_custom_ip_ranges' do


### PR DESCRIPTION
added posibility to send requests to servers configured with self signed certificates.

https://ruby-doc.org/stdlib-3.0.2/libdoc/net/http/rdoc/Net/HTTP.html#ca_file-attribute-method